### PR TITLE
:wrench: Fix: TimeZome修正

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,7 +31,9 @@ module TraGori
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
+    
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end


### PR DESCRIPTION
## PR内容
- `TimeZone`が`UTC`になっていたため、`JST`に修正。