### PR TITLE
:lipstick: Update: #98 イラスト詳細画面のモーダル化

### DIFF
--- a/app/javascript/controllers/album_modal_controller.js
+++ b/app/javascript/controllers/album_modal_controller.js
@@ -1,0 +1,50 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="album-modal"
+export default class extends Controller {
+  // ターゲットの定義
+  static targets = ["albumModal", "background"]
+
+  // connectメソッドは、HTMLからコントローラーに繋がれた際に呼ばれるアクション
+  connect() {
+    this.currentModalId = null;
+  }
+
+  // 『イラスト説明』リンククリック時に、モーダルを表示するアクション
+  openModal(event) {
+    event.preventDefault();
+    const illustrationId = event.currentTarget.getAttribute("data-illustration-id");
+    const modalId = `illustrationModal-${illustrationId}`;
+    const modal = document.getElementById(modalId);
+    if (modal) {
+      modal.classList.remove("hidden");
+      document.body.setAttribute("data-current-modal-id", modalId); // モーダルIDを<body>のデータ属性として保存
+    } else {
+      console.error(`Element with ID ${modalId} not found`); // コンソール確認用
+    }
+  }
+
+  // モーダルを閉じるアクション
+  closeModal() {
+    const modalId = document.body.getAttribute("data-current-modal-id"); // <body>からモーダルIDを取得
+    const modal = document.getElementById(modalId);
+    if (modal) {
+      modal.classList.add("hidden");
+      document.body.removeAttribute("data-current-modal-id"); // データ属性のクリア
+    } else {
+      console.error(`Element with ID ${modalId} not found`); // コンソール確認用
+    }
+  }
+
+  // モーダルの外をクリックした際に、モーダルを閉じるアクション
+  closeBackground(event) {
+    // イベントハンドラ内のターゲットとbackGroundTargetが同じ場合trueを返す。(モーダル外をクリックしているか確認)
+    if(event.target === this.backgroundTarget) {
+      this.closeModal();
+    }
+  }
+
+  doNothing(event) {
+    event.stopPropagation();
+  }
+}

--- a/app/views/albums/_show.html.erb
+++ b/app/views/albums/_show.html.erb
@@ -1,0 +1,13 @@
+<div id="illustrationModal-<%= illustration.id %>" class="hidden fixed inset-0 bg-gray-600 bg-opacity-50 flex items-center justify-center"
+      data-controller="album-modal"
+      data-album-modal-target="background"
+      data-action="click->album-modal#closeBackground">
+  <div class="relative border p-5 shadow-lg rounded-md bg-white"
+        style="width: 500px;"
+        data-album-modal-target="albumModal"
+        data-action="click->album-modal#doNothing">
+    <%= image_tag illustration.image_url, alt: illustration.title, size: "350x350", class:"mx-auto" %>
+    <h2 class="text-base md:text-lg mt-10 text-center">『 <%= illustration.title %> 』</h2>
+    <h2 class="text-base md:text-lg mt-10 mb-5 text-center">「<%= illustration.description %>」</h2>
+  </div>
+</div>

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -19,17 +19,21 @@
           </div>
         </div>
       <% else %>
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-20">
-          <% @illustrations.each do |illustration| %>
-            <div class="bg-white p-6 rounded-lg shadow-xl mx-3 border border-gray-500">
-              <h1 class="text-xl md:text-2xl text-center mb-10">《 Gorilla No. <%= illustration.id %> 》</h1>
-              <%= image_tag illustration.image_url, alt: illustration.title, size: "850x850", class:"mx-auto" %>
-              <div class="pt-20 text-center">
-                <%= link_to "イラスト説明", user_album_path(id: illustration),
-                  class: "inline-block actions rounded-lg bg-customYellow3 py-3 px-4 mb-5 w-68 transition ease-in-out hover:bg-customYellow4 hover:drop-shadow-lg hover:-translate-y-1 active:scale-95 active:bg-customYellow4" %>
+        <div data-controller="album-modal">
+          <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-20">
+            <% @illustrations.each do |illustration| %>
+              <div class="bg-white p-6 rounded-lg shadow-xl mx-3 border border-gray-500">
+                <h1 class="text-xl md:text-2xl text-center mb-10">《 Gorilla No. <%= illustration.id %> 》</h1>
+                <%= image_tag illustration.image_url, alt: illustration.title, size: "850x850", class:"mx-auto" %>
+                <div class="pt-20 text-center">
+                  <%= link_to "イラスト説明", "#",
+                    class: "inline-block actions rounded-lg bg-customYellow3 py-3 px-4 mb-5 w-68 transition ease-in-out hover:bg-customYellow4 hover:drop-shadow-lg hover:-translate-y-1 active:scale-95 active:bg-customYellow4",
+                    data: { action: "click->album-modal#openModal", "illustration-id": illustration.id } %>
+                </div>
               </div>
-            </div>
-          <% end %>
+              <%= render 'show', illustration: illustration %>
+            <% end %>
+          </div>
         </div>
       <% end %>
     </section>

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -1,26 +1,19 @@
-<% content_for :title do %>
-  <%= t('.title') %>《No. <%= @illustration.id %>》
-<% end %>
-<div class="min-h-screen flex flex-col justify-center items-center">
-  <div class="container mx-auto px-10">
-    <header class="text-center my-12">
-      <h1 class="text-4xl"><%= t(".title") %></h1>
-    </header>
-    <section>
-      <div class="grid grid-cols-1 gap-4 mb-20">
-        <div class="bg-white p-6 rounded-lg shadow-xl mx-3 border border-gray-500">
-          <%= image_tag @illustration.image_url, alt: @illustration.title, size: "800x800", class:"mx-auto" %>
-          <h2 class="text-2xl md:text-3xl mt-20 text-center">《 Gorilla No. <%= @illustration.id %> 》</h2>
-          <h2 class="text-xl md:text-2xl mt-8 text-center">『 <%= @illustration.title %> 』</h2>
-          <h2 class="text-lg md:text-xl my-20 text-center">「<%= @illustration.description %>」</h2>
+<%= turbo_frame_tag "album_modal" do %>
+  <div class="hidden fixed inset-0 bg-gray-600 bg-opacity-50 flex items-center justify-center" data-controller="album_modal" data-album-modal-target="backGround" data-action="click->album_modal#closeBackground">
+    <div class="relative p-5 border w-96 shadow-lg rounded-md bg-white" data-album-modal-target="albumModal">
+      <header class="text-center my-12">
+        <h1 class="text-4xl"><%= t(".title") %></h1>
+      </header>
+      <section>
+        <div class="grid grid-cols-1 gap-4 mb-20">
+          <div class="bg-white p-6 rounded-lg shadow-xl mx-3 border border-gray-500">
+            <%= image_tag @illustration.image_url, alt: @illustration.title, size: "800x800", class:"mx-auto" %>
+            <h2 class="text-2xl md:text-3xl mt-20 text-center">《 Gorilla No. <%= @illustration.id %> 》</h2>
+            <h2 class="text-xl md:text-2xl mt-8 text-center">『 <%= @illustration.title %> 』</h2>
+            <h2 class="text-lg md:text-xl my-20 text-center">「<%= @illustration.description %>」</h2>
+          </div>
         </div>
-      </div>
-    </section>
-    <div class="mt-5 text-center">
-      <%= link_to "ゴリアルバムへ戻る", user_albums_path(current_user), class: "inline-block actions rounded-lg bg-customYellow3 py-3 px-4 mb-5 w-68 transition ease-in-out hover:bg-customYellow4 hover:drop-shadow-lg hover:-translate-y-1 active:scale-95 active:bg-customYellow4" %>
-    </div>
-    <div class="mt-5 mb-10 text-center">
-      <%= link_to "ホーム画面へ戻る", training_records_path, class: "inline-block actions rounded-lg bg-gray-400 py-3 px-4 mb-5 w-68 transition ease-in-out hover:bg-gray-500 hover:drop-shadow-lg hover:-translate-y-1 active:scale-95 active:bg-gray-500" %>
+      </section>
     </div>
   </div>
-</div>
+<% end %>


### PR DESCRIPTION
## PR内容
- イラスト詳細画面のモーダル画面化
　
## 詳細
- 『ゴリアルバム』内の「イラスト説明」ボタンクリック時、クリックしたイラストの詳細画面`show_html.erb`に遷移していたが、モーダルウィンドウでイラスト詳細の確認が出来るように変更。